### PR TITLE
Fix TimeRange import circular dependency

### DIFF
--- a/freqtrade/commands/data_commands.py
+++ b/freqtrade/commands/data_commands.py
@@ -44,7 +44,8 @@ def start_download_data(args: dict[str, Any]) -> None:
 
 
 def start_convert_trades(args: dict[str, Any]) -> None:
-    from freqtrade.configuration import TimeRange, setup_utils_configuration
+    from freqtrade.configuration import setup_utils_configuration
+    from freqtrade.configuration.timerange import TimeRange
     from freqtrade.data.converter import convert_trades_to_ohlcv
     from freqtrade.resolvers import ExchangeResolver
 

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -70,7 +70,6 @@ def validate_config_schema(conf: dict[str, Any], preliminary: bool = False) -> d
         raise ValidationError(best_match(Draft4Validator(conf_schema).iter_errors(conf)).message)
 
 
-
 def validate_config_consistency(
     conf: dict[str, Any], *, preliminary: bool = False, strategy: IStrategy | None = None
 ) -> None:

--- a/freqtrade/data/converter/trade_converter.py
+++ b/freqtrade/data/converter/trade_converter.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pandas as pd
 from pandas import DataFrame, to_datetime
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import (
     DEFAULT_DATAFRAME_COLUMNS,
     DEFAULT_TRADES_COLUMNS,

--- a/freqtrade/data/dataprovider.py
+++ b/freqtrade/data/dataprovider.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pandas import DataFrame, Timedelta, Timestamp, to_timedelta
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import (
     FULL_DATAFRAME_THRESHOLD,
     Config,

--- a/freqtrade/data/entryexitanalysis.py
+++ b/freqtrade/data/entryexitanalysis.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import Config
 from freqtrade.data.btanalysis import (
     BT_DATA_COLUMNS,

--- a/freqtrade/data/history/datahandlers/featherdatahandler.py
+++ b/freqtrade/data/history/datahandlers/featherdatahandler.py
@@ -2,7 +2,7 @@ import logging
 
 from pandas import DataFrame, read_feather, to_datetime
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS, DEFAULT_TRADES_COLUMNS
 from freqtrade.enums import CandleType, TradingMode
 

--- a/freqtrade/data/history/datahandlers/idatahandler.py
+++ b/freqtrade/data/history/datahandlers/idatahandler.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from pandas import DataFrame, to_datetime
 
 from freqtrade import misc
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import DEFAULT_TRADES_COLUMNS, ListPairsWithTimeframes
 from freqtrade.data.converter import (
     clean_ohlcv_dataframe,

--- a/freqtrade/data/history/datahandlers/jsondatahandler.py
+++ b/freqtrade/data/history/datahandlers/jsondatahandler.py
@@ -4,7 +4,7 @@ import numpy as np
 from pandas import DataFrame, read_json, to_datetime
 
 from freqtrade import misc
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS, DEFAULT_TRADES_COLUMNS
 from freqtrade.data.converter import trades_dict_to_list, trades_list_to_df
 from freqtrade.enums import CandleType, TradingMode

--- a/freqtrade/data/history/datahandlers/parquetdatahandler.py
+++ b/freqtrade/data/history/datahandlers/parquetdatahandler.py
@@ -2,7 +2,7 @@ import logging
 
 from pandas import DataFrame, read_parquet, to_datetime
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import DEFAULT_DATAFRAME_COLUMNS, DEFAULT_TRADES_COLUMNS
 from freqtrade.enums import CandleType, TradingMode
 

--- a/freqtrade/data/history/history_utils.py
+++ b/freqtrade/data/history/history_utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from pandas import DataFrame, concat
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import DATETIME_PRINT_FORMAT, DL_DATA_TIMEFRAMES, DOCS_LINK, Config
 from freqtrade.data.converter import (
     clean_ohlcv_dataframe,

--- a/freqtrade/freqai/data_drawer.py
+++ b/freqtrade/freqai/data_drawer.py
@@ -17,7 +17,7 @@ from joblib.externals import cloudpickle
 from numpy.typing import NDArray
 from pandas import DataFrame
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import Config
 from freqtrade.data.history import load_pair_history
 from freqtrade.enums import CandleType

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -15,7 +15,7 @@ from datasieve.pipeline import Pipeline
 from pandas import DataFrame
 from sklearn.model_selection import train_test_split
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import DOCS_LINK, ORDERFLOW_ADDED_COLUMNS, Config
 from freqtrade.data.converter import reduce_dataframe_footprint
 from freqtrade.exceptions import OperationalException

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -17,7 +17,7 @@ from numpy.typing import NDArray
 from pandas import DataFrame
 from sklearn.preprocessing import MinMaxScaler
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import DOCS_LINK, Config
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.enums import RunMode

--- a/freqtrade/freqai/utils.py
+++ b/freqtrade/freqai/utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import rapidjson
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import Config
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history.history_utils import refresh_backtest_ohlcv_data

--- a/freqtrade/optimize/base_analysis.py
+++ b/freqtrade/optimize/base_analysis.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from pandas import DataFrame
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 
 
 logger = logging.getLogger(__name__)

--- a/freqtrade/plot/plotting.py
+++ b/freqtrade/plot/plotting.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import Config
 from freqtrade.data.btanalysis import (
     analyze_trade_parallelism,

--- a/tests/data/test_btanalysis.py
+++ b/tests/data/test_btanalysis.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 import pytest
 from pandas import DataFrame, DateOffset, Timestamp, to_datetime
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import LAST_BT_RESULT_FN
 from freqtrade.data.btanalysis import (
     BT_DATA_COLUMNS,

--- a/tests/data/test_datahandler.py
+++ b/tests/data/test_datahandler.py
@@ -9,7 +9,7 @@ import pytest
 from pandas import DataFrame, Timestamp
 from pandas.testing import assert_frame_equal
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import AVAILABLE_DATAHANDLERS
 from freqtrade.data.history.datahandlers.featherdatahandler import FeatherDataHandler
 from freqtrade.data.history.datahandlers.idatahandler import (

--- a/tests/data/test_history.py
+++ b/tests/data/test_history.py
@@ -12,7 +12,7 @@ import pytest
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import DATETIME_PRINT_FORMAT
 from freqtrade.data.converter import ohlcv_to_dataframe
 from freqtrade.data.history import get_datahandler

--- a/tests/freqai/conftest.py
+++ b/tests/freqai/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.freqai.data_drawer import FreqaiDataDrawer
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen

--- a/tests/freqai/test_freqai_datadrawer.py
+++ b/tests/freqai/test_freqai_datadrawer.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.exceptions import OperationalException
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen

--- a/tests/freqai/test_freqai_datakitchen.py
+++ b/tests/freqai/test_freqai_datakitchen.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.exceptions import OperationalException
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen

--- a/tests/freqai/test_freqai_interface.py
+++ b/tests/freqai/test_freqai_interface.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.enums import RunMode
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -13,7 +13,7 @@ import pytest
 
 from freqtrade import constants
 from freqtrade.commands.optimize_commands import setup_optimize_configuration, start_backtesting
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import BT_DATA_COLUMNS, evaluate_result_multi
 from freqtrade.data.converter import clean_ohlcv_dataframe, ohlcv_fill_up_missing_data

--- a/tests/optimize/test_backtesting_adjust_position.py
+++ b/tests/optimize/test_backtesting_adjust_position.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.data import history
 from freqtrade.data.history import get_timerange
 from freqtrade.enums import ExitType

--- a/tests/optimize/test_optimize_reports.py
+++ b/tests/optimize/test_optimize_reports.py
@@ -10,7 +10,7 @@ import joblib
 import pandas as pd
 import pytest
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import BACKTEST_BREAKDOWNS, DATETIME_PRINT_FORMAT, LAST_BT_RESULT_FN
 from freqtrade.data import history
 from freqtrade.data.btanalysis import (

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from pandas import DataFrame, concat
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.constants import CUSTOM_TAG_MAX_LENGTH
 from freqtrade.data.dataprovider import DataProvider
 from freqtrade.data.history import load_data

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -7,7 +7,7 @@ import pytest
 from plotly.subplots import make_subplots
 
 from freqtrade.commands import start_plot_dataframe, start_plot_profit
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.data import history
 from freqtrade.data.btanalysis import load_backtest_data
 from freqtrade.data.metrics import create_cum_profit

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from freqtrade.configuration import TimeRange
+from freqtrade.configuration.timerange import TimeRange
 from freqtrade.exceptions import OperationalException
 
 


### PR DESCRIPTION
## Summary
- avoid importing TimeRange via `freqtrade.configuration` to remove circular import

## Testing
- `ruff check .`
- `mypy freqtrade`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy' / ta-lib build failed)*

------
https://chatgpt.com/codex/tasks/task_e_6873f1bdf67c832d84fb1b75b79ee519